### PR TITLE
posts ("pages") for topics

### DIFF
--- a/knowledge/addPost.php
+++ b/knowledge/addPost.php
@@ -1,25 +1,36 @@
 <?php
-    $add = fileWriteAppend();
-    file_put_contents('posts.json', $add);
 
+    function generateAuthCode() {
+        $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $charactersLength = strlen($characters);
+        $authCode = '';
+        for ($i = 0; $i < 6; $i++) {
+            $authCode .= $characters[rand(0, $charactersLength - 1)];
+        }
+        return $authCode;
+    }
 
-    function fileWriteAppend(){
-        $title = $_POST["title"];
-        $content = $_POST["content"];
-        $currentDate = $_POST["currentDate"];
-        $user = $_POST["user"];
-        $tags = $_POST["tags"];
-		$current_data = file_get_contents('posts.json');
-        $array_data = json_decode($current_data, true);
-        if (!$array_data) {
-            $id = 1;
-        }
-        else {
-            $id = $array_data[count($array_data)-1]['id'] + 1;
-        }
-        $new = array('id' => $id,'title' => $title, 'body' => $content, 'from'=>$user,'tags'=>$tags, 'lastUpdated' => $currentDate, 'lastUpdatedBy' => $user, 'comments' => array());
-		$array_data[] = $new;
-		$final_data = json_encode($array_data);
-		return $final_data;
-}
+    include("../DBCredentials.php");
+
+    $conn = mysqli_connect($servername, $username, $password, $dbname);
+
+    if (!$conn) {
+        die("Connection failed: " . mysqli_connect_error());
+    }
+
+    $postID = generateAuthCode();
+    $topicNames = $_POST["associatedTopics"];
+    $pageName = $_POST["pageName"];
+    $topicDescription = $_POST["topicDescription"];
+    $postDate = date("d/m/Y");
+    $author = $_POST["author"];
+    $sql = "INSERT INTO posts VALUES ('$postID', '$pageName', '$topicDescription','$postDate','$author')";
+    $result = mysqli_query($conn, $sql);
+    $sql = "INSERT INTO topicToPostMapping VALUES ((SELECT topicID FROM topics WHERE topics.name = '$topicNames'),'$postID')";
+    $result = mysqli_query($conn, $sql);
+    if ($result == false){
+        echo "false";
+    } else {
+        echo "true";
+    }
 ?>

--- a/knowledge/getPosts.php
+++ b/knowledge/getPosts.php
@@ -1,0 +1,24 @@
+<?php
+include("../DBCredentials.php");
+
+$conn = mysqli_connect($servername, $username, $password, $dbname);
+
+if (!$conn) {
+	die("Connection failed: " . mysqli_connect_error());
+}
+
+$name = $_POST["topicName"];
+$sql = "SELECT * FROM posts WHERE postID IN (SELECT postID FROM topicToPostMapping WHERE topicID = (SELECT topicID FROM topics WHERE topics.name = '$name'))";
+$result = mysqli_query($conn, $sql);
+if (mysqli_num_rows($result)>0){
+    $allDataArray = array();
+    while ($row = mysqli_fetch_array($result, MYSQLI_ASSOC)){
+        $allDataArray[] = $row;
+    }
+    echo json_encode($allDataArray);
+} else {
+    echo "false";
+}
+
+
+?>

--- a/knowledge/retrievePosts.php
+++ b/knowledge/retrievePosts.php
@@ -1,6 +1,0 @@
-<?php
-$file = fopen("posts.json", "r") or die("Unable to find file!");
-$json_data = file_get_contents('posts.json');
-
-echo $json_data;
-?>

--- a/knowledge/wiki.php
+++ b/knowledge/wiki.php
@@ -21,18 +21,17 @@ session_start();
         $("#addTaskButton").hide();
       };
 
-      $("#addPostForm").submit(function(event){
+      $("#addTopicForm").submit(function(event){
         event.preventDefault();
-          let topicName = $("#topicName").val();
-          let technical = localStorage.getItem("technical");
+        let topicName = $("#topicName").val();
+        let technical = localStorage.getItem("technical");
           $.ajax({
             url:"knowledge/addTopics.php",
             type:"POST",
             data: {topicName : topicName, technical: technical},
             success: function(responseData){
-              console.log(responseData);
                 if (responseData === "true"){
-                  $('#addPostModal').modal('hide');
+                  $('#addTopicModal').modal('hide');
                   $('body').removeClass('modal-open');
                   $('.modal-backdrop').remove();
                   location.reload();
@@ -49,8 +48,36 @@ session_start();
         event.preventDefault();       
           
       });
+    $("#addPageForm").submit(function(event){
+      event.preventDefault();
+      let pageName = $("#pageName").val();
+      let topicDescription = $("#pageDescription").val();
+      let associatedTopics = localStorage.getItem("topicName");
+      let author = ('<?php echo substr($_SESSION['email'], 0, strpos($_SESSION['email'], "@"));?>');
+      $.ajax({
+          url:"knowledge/addPost.php",
+          type:"POST",
+          data: {pageName : pageName, topicDescription: topicDescription, associatedTopics: associatedTopics,author : author},
+          success: function(responseData){
+              if (responseData === "true"){
+                $('#addPageModal').modal('hide');
+                $('body').removeClass('modal-open');
+                $('.modal-backdrop').remove();
+                location.reload();
+              } else {
+                  window.alert("Error!");
+              }
+          },
+          error: function(e){
+              window.alert("Error Occurred! Please refer to console.");
+              console.log(e.message);
+          }
+      });
+
+      event.preventDefault();       
+        
     });
-    
+  });
     
     function searchFilter(x) {
         var posts = document.getElementsByClassName("letter");
@@ -97,14 +124,14 @@ session_start();
       <li><a href="#" id = 'deleteMenu'>Delete</a></li>
   </ul>
 </div>
-<div class="modal" id="addPostModal" tabindex="-1" role="dialog" aria-labelledby="addPostModalLabel" aria-hidden="true">
+<div class="modal" id="addTopicModal" tabindex="-1" role="dialog" aria-labelledby="addTopicModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="filterTaskModalLabel">Create new topic - <span style="font-size:1rem;"> Logged in as: <? echo substr($_SESSION['email'], 0, strpos($_SESSION['email'], "@")); ?></span>  </h5>
                 </div>
                 <div class="modal-body">
-                    <form id="addPostForm">
+                    <form id="addTopicForm">
                         <div class="form-group">
                             <input hidden type="text" id="user" value="<?php echo substr($_SESSION['email'], 0, strpos($_SESSION['email'], "@"));?>">
                             <label for="topicName">Topic Name</label>
@@ -117,6 +144,32 @@ session_start();
         </div>
     </div>
 
+<div class="modal" id="addPageModal" tabindex="-1" role="dialog" aria-labelledby="addPageModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="filterTaskModalLabel">Create new Page - <span style="font-size:1rem;"> Logged in as: <? echo substr($_SESSION['email'], 0, strpos($_SESSION['email'], "@")); ?></span>  </h5>
+            </div>
+            <div class="modal-body">
+                <form id="addPageForm">
+                    <div class="form-group">
+                        <input hidden type="text" id="user" value="<?php echo substr($_SESSION['email'], 0, strpos($_SESSION['email'], "@"));?>">
+                        <label for="PageName">Page Name</label>
+                        <input type="text" class="form-control" id="pageName" name="pageName" placeholder="Page Name">
+                        <br>
+                        <label for="PageDescription">Page Description</label>
+                        <textarea id="pageDescription" class="form-control" placeholder = 'Enter Description' name="pageDescription" rows="4" cols="50"></textarea>
+                        <br>
+                        <label for="Author" id = "Author">Author - <?php echo substr($_SESSION['email'], 0, strpos($_SESSION['email'], "@"));?></label>
+                        <br>
+                        <label for = "Date" id = "Date"></label>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Publish</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
 
 <div id="knowledgeDiv" style = 'height: 100vh;'>
 <div id="mainDiv" class = 'flex-master'>
@@ -124,14 +177,16 @@ session_start();
   <div style="width:100%" id="Options">
       <h5 style="padding-top:27px;">Options</h5>
       <hr class="my-4">
-      <div class="input-group rounded">
+      <!-- change to js -->
+      <div class="input-group rounded">      
         <input type="search" value = "" class="form-control rounded" placeholder="Search Topic" id="wordSelect" onchange="searchFilter(this.value)" aria-label="Search" aria-describedby="search-addon" />
         <span class="input-group-text border-0" id="search-addon">
           <i class="fas fa-search"></i>
-        </span>
+        </span>       
       </div>
     <div style = 'margin-top: 20px;'>
-      <button class="btn btn-primary" id='addTaskButton' type="button" data-bs-toggle="modal" data-bs-target="#addPostModal" aria-controls="addPostModal">Create Topic</button>
+      <!-- change to js -->
+      <button class="btn btn-primary" id='addTaskButton' type="button" data-bs-toggle="modal" data-bs-target="#addTopicModal" aria-controls="addTopicModal">Add Topic</button>
       <br>
       <br>
       <button class="btn btn-primary" id='FAQButton' type="button" onclick="navclick('/knowledge/faq.php')">FAQ</button>
@@ -143,7 +198,7 @@ session_start();
 
 <div id="contentDiv" style = 'width:80%;'>
 <div style = 'width: 100%;'>
-<h1 id = 'chooseTopic'></h1>
+<h1 id = 'chooseTopic'></h1> <!-- change innerHTML -->
 <a href='#' id = 'prev'>Prev Page</a>
 <div style = 'margin-left: 70%; display: inline;'>
 <a href='#' id = 'next'>Next Page</a>
@@ -151,14 +206,6 @@ session_start();
 <hr style = 'border-top: 1px solid black;'>
   </div>
   <div class="container" style = 'height: 85%; column-count:5; column-fill: auto; margin-left: 0px;'>
-  <div class = "letter">
-    <h1>A</h1>
-    <li><a href = 'google.com'>test</a></li>
-  </div>
-  <div class = "letter">
-    <h1>B</h1>
-      <li><a href = 'google.com'>test</a></li>
-  </div>
   </div>
   <div id = 'notFound' style = 'text-align: center;'></div>
   </div>
@@ -169,69 +216,147 @@ session_start();
   
    $(document).ready(function(){
       localStorage.setItem("currentPage", "knowledge/wiki.php");
-      (localStorage.getItem("technical") == 1) ? document.getElementById('chooseTopic').innerHTML = 'Choose Technical Topic' : document.getElementById('chooseTopic').innerHTML = 'Choose non Technical Topic';
+      if (localStorage.getItem("posts") === '0') {
+        (localStorage.getItem("technical") == 1) ? document.getElementById('chooseTopic').innerHTML = 'Choose Technical Topic' : document.getElementById('chooseTopic').innerHTML = 'Choose non Technical Topic';
+      }
+      else {
+        document.getElementById('chooseTopic').innerHTML = `Choose Post Associated With "${localStorage.getItem("topicName")}"`; 
+        document.getElementById("addTaskButton").innerHTML = 'Add Page';
+        document.getElementById("addTaskButton").setAttribute("data-bs-target", "#addPageModal");
+        document.getElementById("addTaskButton").setAttribute("aria-controls", "addPageModal");
+        const date = new Date();
+        let day = date.getDate() > 9 ? date.getDate() : '0' + date.getDate();
+        let month = date.getMonth() + 1 > 9 ? (date.getMonth() + 1): '0' + (date.getMonth() + 1);
+        let year = date.getFullYear();
+        document.getElementById("Date").innerHTML = `Published on - ${day}/${month}/${year}`;
+      }
+      let pageName = $("#PageName").val();
+      let topicDescription = $("#PageDescription").val();
     });
 
     const maxItemsOnScreen = 90;
-    console.log(typeof maxItemsOnScreen);
-    var bottom = localStorage.hasOwnProperty('bottom') ? Number(localStorage.getItem("bottom")) : 0;
-    var top1 = localStorage.hasOwnProperty('top') ? Number(localStorage.getItem("top")) : maxItemsOnScreen;
+    var lower = localStorage.hasOwnProperty('bottom') ? Number(localStorage.getItem("bottom")) : 0;
+    var higher = localStorage.hasOwnProperty('top') ? Number(localStorage.getItem("top")) : maxItemsOnScreen;
     var topicCount = 0;
-    $.ajax({
-            url:"knowledge/getTopics.php",
-            success: function(responseData){
-                let technical = localStorage.getItem("technical");
-                let temp = JSON.parse(responseData);
-                const letterToTopic = new Map();
-                var posts = document.getElementsByClassName("letter");
-                temp.forEach((topic) => {
-                  if (topic.technical === technical) {
-                    var letter = topic.name.charAt(0).toUpperCase();
-                    letterToTopic.has(letter) ? letterToTopic.get(letter).push(topic.name.charAt(0).toUpperCase() + topic.name.slice(1)) : letterToTopic.set(letter,[topic.name.charAt(0).toUpperCase() + topic.name.slice(1)]);
-                }
-              });
-
-            document.getElementsByClassName("container")[0].innerHTML = '';
-            const sortedLetterToTopic = new Map([...letterToTopic].sort());
-            sortedLetterToTopic.forEach((value, key) => {
-              topicCount += 3;
-              if (bottom <= topicCount && top1 > topicCount) {
-              var container = document.getElementsByClassName("container")[0];
-              var letterDiv = document.createElement("div");
-              var h1 = document.createElement("h1");
-              h1.appendChild(document.createTextNode(key));
-              letterDiv.appendChild(h1);
-              letterDiv.setAttribute("class", "letter");
-              value.sort().forEach((topicName) => {
-                  topicCount += 1;
-                  var a = document.createElement("a");
-                  var li = document.createElement("li");
-                  a.setAttribute("href","#");
-                  a.appendChild(document.createTextNode(topicName));
-                  document.onclick = hideMenu;
-                  if (<?php echo ($_SESSION['isAdmin'])?>) {
-                      a.oncontextmenu = rightClick(topicName);
+    if (localStorage.getItem("posts") === '0') {
+      $.ajax({
+              url:"knowledge/getTopics.php",
+              success: function(responseData){
+                  let technical = localStorage.getItem("technical");
+                  let temp = JSON.parse(responseData);
+                  const letterToTopic = new Map();
+                  var posts = document.getElementsByClassName("letter");
+                  temp.forEach((topic) => {
+                    if (topic.technical === technical) {
+                      var letter = topic.name.charAt(0).toUpperCase();
+                      letterToTopic.has(letter) ? letterToTopic.get(letter).push(topic.name.charAt(0).toUpperCase() + topic.name.slice(1)) : letterToTopic.set(letter,[topic.name.charAt(0).toUpperCase() + topic.name.slice(1)]);
                   }
-                  li.appendChild(a);
-                  letterDiv.appendChild(li);
-                
-              });
-              container.appendChild(letterDiv);
-              }
-              else {
-                value.forEach((topicName) => {
-                  topicCount += 1;
                 });
-              }
-            document.getElementById("next").style.display = top1 <= topicCount ? "inline" : 'None';
-            document.getElementById("prev").style.display = bottom > 0 ? "inline" : 'None';
-            });
-            },
-            error: function(e){
-                console.log(e.message);
-            }
-        });
 
+              document.getElementsByClassName("container")[0].innerHTML = '';
+              const sortedLetterToTopic = new Map([...letterToTopic].sort());
+              sortedLetterToTopic.forEach((value, key) => {
+                topicCount += 3;
+                if (lower <= topicCount && higher > topicCount) {
+                var container = document.getElementsByClassName("container")[0];
+                var letterDiv = document.createElement("div");
+                var h1 = document.createElement("h1");
+                h1.appendChild(document.createTextNode(key));
+                letterDiv.appendChild(h1);
+                letterDiv.setAttribute("class", "letter");
+                value.sort().forEach((topicName) => {
+                    topicCount += 1;
+                    var a = document.createElement("a");
+                    var li = document.createElement("li");
+                    a.setAttribute("href","#");
+                    a.setAttribute("onclick","getPosts(this);");
+                    a.appendChild(document.createTextNode(topicName));
+                    document.onclick = hideMenu;
+                    if (<?php echo ($_SESSION['isAdmin'])?>) {
+                        a.oncontextmenu = rightClick(topicName);
+                    }
+                    li.appendChild(a);
+                    letterDiv.appendChild(li);
+                  
+                });
+                container.appendChild(letterDiv);
+                }
+                else {
+                  value.forEach((topicName) => {
+                    topicCount += 1;
+                  });
+                }
+              document.getElementById("next").style.display = higher <= topicCount ? "inline" : 'None';
+              document.getElementById("prev").style.display = lower > 0 ? "inline" : 'None';
+              });
+              },
+              error: function(e){
+                  console.log(e.message);
+              }
+          });
+        }
+
+      else {
+        let topicName = localStorage.getItem("topicName");
+        $.ajax({
+          type:"POST",
+          data: {topicName : topicName},
+          url:"knowledge/getPosts.php",
+          success: function(responseData){
+            if (responseData === 'false') {
+              document.getElementsByClassName("container")[0].style.display = 'None';
+              document.getElementById("notFound").innerHTML = `Couldn't find any pages associated with "${topicName}".`;
+            }
+            else {
+              let temp = JSON.parse(responseData);
+                  const letterToPage = new Map();
+                  var posts = document.getElementsByClassName("letter");
+                  temp.forEach((page) => {
+                    var letter = page.name.charAt(0).toUpperCase();
+                    letterToPage.has(letter) ? letterToPage.get(letter).push(page.name.charAt(0).toUpperCase() + page.name.slice(1)) : letterToPage.set(letter,[page.name.charAt(0).toUpperCase() + page.name.slice(1)]);
+                });
+              document.getElementsByClassName("container")[0].innerHTML = '';
+              const sortedLetterToPage = new Map([...letterToPage].sort());
+              sortedLetterToPage.forEach((value, key) => {
+                topicCount += 3;
+                if (lower <= topicCount && higher > topicCount) {
+                  var container = document.getElementsByClassName("container")[0];
+                  var letterDiv = document.createElement("div");
+                  var h1 = document.createElement("h1");
+                  h1.appendChild(document.createTextNode(key));
+                  letterDiv.appendChild(h1);
+                  letterDiv.setAttribute("class", "letter");
+                  value.sort().forEach((pageName) => {
+                    topicCount += 1;
+                    var a = document.createElement("a");
+                    var li = document.createElement("li");
+                    a.setAttribute("href","#");
+                    a.appendChild(document.createTextNode(pageName));
+                    document.onclick = hideMenu;
+                    if (<?php echo ($_SESSION['isAdmin'])?>) {
+                        a.oncontextmenu = rightClick(pageName);
+                    }
+                    li.appendChild(a);
+                    letterDiv.appendChild(li);
+                    
+                  });
+                  container.appendChild(letterDiv);
+                }
+                else {
+                  value.forEach((pageName) => {
+                    topicCount += 1;
+                  });
+                }
+              document.getElementById("next").style.display = higher <= topicCount ? "inline" : 'None';
+              document.getElementById("prev").style.display = lower > 0 ? "inline" : 'None';
+              });
+            }
+      },
+        error: function(e){
+            console.log(e.message);
+        }
+      });
+    }
 
   function hideMenu() {
       document.getElementById(
@@ -253,7 +378,6 @@ session_start();
           menu.style.display = 'block';
           menu.style.left = e.pageX + "px";
           menu.style.top = e.pageY + "px";
-          console.log(menu.title);
       }
     }
   }
@@ -275,22 +399,28 @@ session_start();
     });
   });
 
+  function getPosts(ele) {
+    localStorage.setItem("posts",1);
+    localStorage.setItem("topicName",ele.innerHTML);
+    location.reload();
+  }
+
   $("#next").click(function() {
-    if (top1 <= topicCount){
-      bottom += Number(maxItemsOnScreen);
-      top1 += Number(maxItemsOnScreen);
-      localStorage.setItem("bottom", bottom);
-      localStorage.setItem("top", top1);
+    if (higher <= topicCount){
+      lower += Number(maxItemsOnScreen);
+      higher += Number(maxItemsOnScreen);
+      localStorage.setItem("bottom", lower);
+      localStorage.setItem("top", higher);
       location.reload();
     }
   });
 
   $("#prev").click(function() {
-    if (bottom > 0) {
-      bottom -= Number(maxItemsOnScreen);
-      top1 -= Number(maxItemsOnScreen);
-      localStorage.setItem("bottom", bottom);
-      localStorage.setItem("top", top1);
+    if (lower > 0) {
+      lower -= Number(maxItemsOnScreen);
+      higher -= Number(maxItemsOnScreen);
+      localStorage.setItem("bottom", lower);
+      localStorage.setItem("top", higher);
       location.reload();
     }
   });

--- a/knowledge/wiki.php
+++ b/knowledge/wiki.php
@@ -191,6 +191,9 @@ session_start();
       <br>
       <button class="btn btn-primary" id='FAQButton' type="button" onclick="navclick('/knowledge/faq.php')">FAQ</button>
   </div>
+  <br>
+  <div id = 'return'>
+  </div>
     </div>
 </section>
 
@@ -217,6 +220,7 @@ session_start();
    $(document).ready(function(){
       localStorage.setItem("currentPage", "knowledge/wiki.php");
       if (localStorage.getItem("posts") === '0') {
+        document.getElementById("return").innerHTML = '';
         (localStorage.getItem("technical") == 1) ? document.getElementById('chooseTopic').innerHTML = 'Choose Technical Topic' : document.getElementById('chooseTopic').innerHTML = 'Choose non Technical Topic';
       }
       else {
@@ -229,9 +233,8 @@ session_start();
         let month = date.getMonth() + 1 > 9 ? (date.getMonth() + 1): '0' + (date.getMonth() + 1);
         let year = date.getFullYear();
         document.getElementById("Date").innerHTML = `Published on - ${day}/${month}/${year}`;
+        document.getElementById("return").innerHTML += `<button type="button" class="btn btn-danger" onclick = 'localStorage.setItem("posts",0); location.reload();'>Return To Topics</button>`;
       }
-      let pageName = $("#PageName").val();
-      let topicDescription = $("#PageDescription").val();
     });
 
     const maxItemsOnScreen = 90;

--- a/navbar.php
+++ b/navbar.php
@@ -56,8 +56,8 @@ session_start();
                     </li>
                     <li class="nav-item " style="text-align:center;">
                         <h4>Knowledge Wiki</h4>
-                        <a id="knowledgeNonTechnical" class="nav-link text-dark" onclick = "localStorage.setItem('technical', 0); navclick('knowledge/wiki.php');">Non-Technical Wiki</a>
-                        <a id="knowledgeTechnical" class="nav-link text-dark" onclick = "localStorage.setItem('technical', 1); navclick('knowledge/wiki.php');">Technical Wiki</a>
+                        <a id="knowledgeNonTechnical" class="nav-link text-dark" onclick = "localStorage.setItem('technical', 0); navclick('knowledge/wiki.php'); localStorage.setItem('posts',0); location.reload();">Non-Technical Wiki</a>
+                        <a id="knowledgeTechnical" class="nav-link text-dark" onclick = "localStorage.setItem('technical', 1); navclick('knowledge/wiki.php'); localStorage.setItem('posts',0); location.reload();">Technical Wiki</a>
                     </li>
                     <?php if($_SESSION['isAdmin'] == true) { echo(
                         "<li class='nav-item ' style='text-align:center;'>


### PR DESCRIPTION
As we discussed I have added another dictionary feature in order to search for posts associated to a topic - 
![image](https://user-images.githubusercontent.com/45899701/211110464-5f5aae10-ad1f-44df-91a5-f0b712c9be5b.png)

Was a bit unsure how we could do this without having _number of topics_ html files so instead decided to use local storage to alter the current page depending on the topic clicked.

Was hoping to get the PR out earlier but a few things were required for the PR including - 

- Getting posts 
- Linking posts to topic
- Creating posts 
- None found result

What I will be working on going forward (which I didn't want to clutter this PR with) - 

- Deleting posts
- Code refinement of all of our components
- Any other features needed for post dictionary
- Finally will look into the pages themselves 

just so it is clear the terms 'posts' and 'pages' are used interchangeably just thought 'page'  sounded more wiki like ? 

As usual give it a test and let me know if I have missed anything :) 